### PR TITLE
Quick lowercase hack to help Windows users

### DIFF
--- a/software/js/packages/example/src/index.ts
+++ b/software/js/packages/example/src/index.ts
@@ -9,7 +9,7 @@ const main = async () => {
         // Implement a check for your device's vendor+product+serial
         // (this is more robust than the alternative of just hardcoding a "path" like "/dev/ttyUSB0")
         return (
-            portInfo.vendorId === '1a86' && portInfo.productId === '7523'
+            portInfo.vendorId?.toLowerCase() === '1a86'.toLowerCase() && portInfo.productId?.toLowerCase() === '7523'.toLowerCase()
             // && portInfo.serialNumber === 'DEADBEEF'
         )
     })


### PR DESCRIPTION
Windows upper cases the vendor and product id, so the filter will fail. So LOWERCASE ALL THE THINGS!