### PR TITLE
Use TFT_eSprite.drawNumber for the current position

### DIFF
--- a/firmware/src/display_task.cpp
+++ b/firmware/src/display_task.cpp
@@ -62,7 +62,7 @@ void DisplayTask::run() {
         }
 
         spr_.setFreeFont(&Roboto_Light_60);
-        spr_.drawString(String() + state.current_position, TFT_WIDTH / 2, TFT_HEIGHT / 2 - VALUE_OFFSET, 1);
+        spr_.drawNumber(state.current_position, TFT_WIDTH / 2, TFT_HEIGHT / 2 - VALUE_OFFSET, 1);
         spr_.setFreeFont(&DESCRIPTION_FONT);
         int32_t line_y = TFT_HEIGHT / 2 + DESCRIPTION_Y_OFFSET;
         char* start = state.config.text;


### PR DESCRIPTION
I would suggest using `drawNumber` instead of drawString to align each digit of the number to the same width and erase the jittering effect when the current position is changed.