### PR TITLE
fix compile errors for SimpleFOC 2.3.1

### DIFF
--- a/firmware/src/motor_task.cpp
+++ b/firmware/src/motor_task.cpp
@@ -79,7 +79,9 @@ void MotorTask::run() {
 
     PB_PersistentConfiguration c = configuration_.get();
     motor.pole_pairs = c.motor.calibrated ? c.motor.pole_pairs : 7;
-    motor.initFOC(c.motor.zero_electrical_offset, c.motor.direction_cw ? Direction::CW : Direction::CCW);
+    motor.zero_electric_angle = c.motor.zero_electrical_offset;
+    motor.sensor_direction = c.motor.direction_cw ? Direction::CW : Direction::CCW;
+    motor.initFOC();
 
     motor.monitor_downsample = 0; // disable monitor at first - optional
 
@@ -354,7 +356,9 @@ void MotorTask::calibrate() {
 
     motor.controller = MotionControlType::angle_openloop;
     motor.pole_pairs = 1;
-    motor.initFOC(0, Direction::CW);
+    motor.zero_electric_angle = 0;
+    motor.sensor_direction = Direction::CW;
+    motor.initFOC();
 
     float a = 0;
 
@@ -397,10 +401,14 @@ void MotorTask::calibrate() {
     log("Sensor measures positive for positive motor rotation:");
     if (end_sensor > start_sensor) {
         log("YES, Direction=CW");
-        motor.initFOC(0, Direction::CW);
+        motor.zero_electric_angle = 0;
+        motor.sensor_direction = Direction::CW;
+        motor.initFOC();
     } else {
         log("NO, Direction=CCW");
-        motor.initFOC(0, Direction::CCW);
+        motor.zero_electric_angle = 0;
+        motor.sensor_direction = Direction::CCW;
+        motor.initFOC();
     }
     snprintf(buf_, sizeof(buf_), "  (start was %.1f, end was %.1f)", start_sensor, end_sensor);
     log(buf_);

--- a/platformio.ini
+++ b/platformio.ini
@@ -17,7 +17,7 @@ test_dir = firmware/test
 data_dir = firmware/data
 
 [base_config]
-platform = espressif32@3.4
+platform = espressif32@6.4.0
 framework = arduino
 monitor_speed = 921600
 monitor_flags = 
@@ -43,7 +43,7 @@ board = esp32doit-devkit-v1
 board_build.partitions = default_ffat.csv
 lib_deps =
   ${base_config.lib_deps}
-  askuric/Simple FOC @ 2.2.0
+  askuric/Simple FOC @ 2.3.1
   bodmer/TFT_eSPI@2.4.25
   fastled/FastLED @ 3.5.0
   bogde/HX711 @ 0.7.5
@@ -134,7 +134,7 @@ board = adafruit_feather_esp32s3
 board_build.partitions = firmware/partitions-4MB-fat.csv
 lib_deps =
   ${base_config.lib_deps}
-  askuric/Simple FOC@2.3.0
+  askuric/Simple FOC@2.3.1
   bodmer/TFT_eSPI@2.5.0
 
 build_flags =


### PR DESCRIPTION
If you're interested, this patch fixes the compile problems with SimpleFOC 2.3.1.

Of course, I don't have a smartknob myself so I can't test it out :-(

The errors are caused by an API change:

`motor.initFOC()` no longer takes the zero angle and direction as parameters. The semantics of that were very complicated and error-prone.

Now the `zero_electrical_angle` and `sensor_direction` can be set on the motor in advance of calling `initFOC()`, like all the other parameters.

If you don't set them, (or set them to NOT_SET, UNKOWN) then the initFOC() will run the calibration. If you provide them in advance, it will skip the calibration.

